### PR TITLE
章節条項号のタイトルの装飾を更新して、色数を抑える

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,13 +5,12 @@
   "description": "An Extension.js example.",
   "content_scripts": [
     {
+      "css": ["./src/content/DecorateLawTitles/lawTitles.css"],
       "matches": ["*://*/*"],
       "js": ["./src/content/index.tsx"]
     }
   ],
-  "icons": {
-    "48": "public/icon-48.png"
-  },
+  "icons": { "48": "public/icon-48.png" },
   "host_permissions": ["*://*/*", "http://localhost/*"],
   "author": "Your Name"
 }

--- a/src/content/DecorateLawTitles/DecorateLawTitles.tsx
+++ b/src/content/DecorateLawTitles/DecorateLawTitles.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { querySelectorAllWithDelay } from "../utils/utils";
+import { querySelectorAllWithDelay } from "../../utils/utils";
 
 /**
  * HACK: テキストに全角数字が含まれているかどうかで、段落タイトルであるかどうかを判定している
@@ -11,18 +11,17 @@ function isParagraphTitle(text: string | null): boolean {
 }
 
 /**
- * span.paragraphtitle をハイライトする処理
+ * span.paragraphtitle に、ハイライト用のクラスを追加する
  */
-async function highlightArticleAndParagraph(): Promise<void> {
+async function addClassToArticleTitleAndParagraphTitle(): Promise<void> {
   try {
     // span.paragraphtitle要素を待機して取得
     const elements = await querySelectorAllWithDelay("span.paragraphtitle");
     elements.forEach((element) => {
       const text = element.textContent;
       // 全角数字が含まれる場合: オレンジ、含まれない場合: 赤
-      element.setAttribute(
-        "style",
-        `color: ${isParagraphTitle(text) ? "orange" : "red"};`
+      element.classList.add(
+        isParagraphTitle(text) ? "paragraph-title" : "article-title"
       );
     });
   } catch (error) {
@@ -32,15 +31,15 @@ async function highlightArticleAndParagraph(): Promise<void> {
 
 /**
  * React コンポーネント:
- * マウント時 (初回レンダリング時) に `highlightArticleAndParagraph` を実行。
+ * マウント時 (初回レンダリング時) に `addClassToArticleAndParagraph` を実行。
  */
-const HighlightParagraph: React.FC = () => {
+const DecorateLawTitles: React.FC = () => {
   useEffect(() => {
-    highlightArticleAndParagraph();
+    addClassToArticleTitleAndParagraphTitle();
   }, []);
 
   // DOM 操作だけを行うため、描画要素は不要
   return null;
 };
 
-export default HighlightParagraph;
+export default DecorateLawTitles;

--- a/src/content/DecorateLawTitles/lawTitles.css
+++ b/src/content/DecorateLawTitles/lawTitles.css
@@ -1,0 +1,46 @@
+:root {
+  --accent-color: #333;
+}
+
+/* 章のタイトル */
+.chaptertitle {
+  color: var(--accent-color);
+  font-size: 1.6em !important;
+  border-bottom: 2px solid var(--accent-color);
+  margin-inline-start: 0px !important;
+  padding-bottom: 8px;
+}
+
+/* 節のタイトル */
+.sectiontitle {
+  color: var(--accent-color);
+  font-size: 1.4em !important;
+  border-bottom: 1px dotted var(--accent-color);
+  margin-inline-start: 0px !important;
+  padding-bottom: 3px;
+}
+
+/* 条のタイトル */
+.article-title {
+  color: var(--accent-color);
+  font-size: 1.2em;
+  padding-left: 8px;
+  border-left: 4px solid var(--accent-color);
+}
+
+/* 項のタイトル */
+.paragraph-title {
+  color: var(--accent-color);
+  padding-left: 16px;
+  border-left: 2px solid var(--accent-color);
+}
+
+/* 号のタイトル */
+span.itemtitle {
+  padding-left: 24px;
+}
+
+/* 号の中で列記する際に使われるタイトル（イ, ロ, ハ, ...） */
+.portiontitle {
+  padding-left: 32px;
+}

--- a/src/content/ExternalLinkPopover/ExternalLinkPopover.tsx
+++ b/src/content/ExternalLinkPopover/ExternalLinkPopover.tsx
@@ -144,10 +144,7 @@ function setupLawPopoverObserver() {
     links.forEach((link) => setupPopover(link as HTMLAnchorElement));
   });
 
-  observer.observe(document.body, {
-    childList: true,
-    subtree: true,
-  });
+  observer.observe(document.body, { childList: true, subtree: true });
 
   const existingLinks = document.querySelectorAll("a[href^='/law/']");
   existingLinks.forEach((link) => setupPopover(link as HTMLAnchorElement));

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -1,9 +1,9 @@
 import ReactDOM from "react-dom/client";
 
 import HighlightBrackets from "./HighlightBrackets";
-import HighlightParagraph from "./HightlightParagraph";
 import HoverTooltip from "./HoverTooltip";
 import ExternalLinkPopover from "./ExternalLinkPopover/ExternalLinkPopover";
+import DecorateLawTitles from "./DecorateLawTitles/DecorateLawTitles";
 
 function initialize() {
   const rootDiv = document.createElement("div");
@@ -15,7 +15,7 @@ function initialize() {
     <>
       <ExternalLinkPopover />
       <HighlightBrackets />
-      <HighlightParagraph />
+      <DecorateLawTitles />
       <HoverTooltip />
     </>
   );


### PR DESCRIPTION
こんな感じ

before
![image (1)](https://github.com/user-attachments/assets/85790de7-d553-4e47-b8a5-84f96936d8ee)

after
![image](https://github.com/user-attachments/assets/15a3469e-c018-4589-8a65-d71358342d54)
