### PR TITLE
略称のバグ修正

### DIFF
--- a/src/content/AbbreviationLinker.tsx
+++ b/src/content/AbbreviationLinker.tsx
@@ -67,8 +67,9 @@ const convertToLink = (node: Text, abbreviations: Abbreviation[]) => {
   matches.sort((a, b) => a.index - b.index);
 
   matches.forEach((match) => {
+    // 重複する箇所はスキップ
     if (match.index < lastIndex) {
-      return; // すでに置換済みの部分はスキップ
+      return;
     }
     // マッチ前のテキストを追加
     container.appendChild(
@@ -95,11 +96,11 @@ const convertToLink = (node: Text, abbreviations: Abbreviation[]) => {
  */
 async function processAbbreviations() {
   try {
-    // .article クラスを持つ要素全体を対象に（<div>、<article>の両方に対応）
-    const elements = await querySelectorAllWithDelay(".article");
+    // .main-content 内の .article 要素全体を対象に（<div>、<article> の両方に対応）
+    const elements = await querySelectorAllWithDelay(".main-content .article");
     const abbreviations: Abbreviation[] = [];
 
-    // 各記事内のすべてのテキストノードから略称定義を収集
+    // 各記事内の全テキストノードから略称定義を収集
     elements.forEach((element) => {
       const textNodes = getTextNodes(element);
       textNodes.forEach((node) => {
@@ -118,7 +119,7 @@ async function processAbbreviations() {
 
     if (abbreviations.length === 0) return;
 
-    // 収集した略称をすべての記事内のテキストノードに適用
+    // 収集した略称を全記事内のテキストノードに適用
     elements.forEach((element) => {
       const textNodes = getTextNodes(element);
       textNodes.forEach((node) => {

--- a/src/content/AbbreviationLinker.tsx
+++ b/src/content/AbbreviationLinker.tsx
@@ -1,4 +1,3 @@
-// AbbreviationLinker.tsx
 import React, { useEffect } from "react";
 import { querySelectorAllWithDelay } from "../utils/utils";
 
@@ -9,6 +8,7 @@ type Abbreviation = {
 
 /**
  * 文字列から略称定義を抽出する
+ * 例：～以下「○○」という。
  */
 const extractAbbreviation = (text: string): string | null => {
   const match = text.match(/以下「([^」]+)」という。/);
@@ -19,44 +19,68 @@ const extractAbbreviation = (text: string): string | null => {
  * 要素のIDを再帰的に取得する
  */
 const findParentId = (element: Element): string | null => {
-  if (!element) return null;
   if (element.id) return element.id;
   return element.parentElement ? findParentId(element.parentElement) : null;
 };
 
 /**
- * テキストノードを略称リンクに変換する
+ * 指定ノード以下のすべてのテキストノードを再帰的に取得する
+ */
+const getTextNodes = (node: Node): Text[] => {
+  let texts: Text[] = [];
+  if (node.nodeType === Node.TEXT_NODE) {
+    texts.push(node as Text);
+  } else {
+    node.childNodes.forEach((child) => {
+      texts = texts.concat(getTextNodes(child));
+    });
+  }
+  return texts;
+};
+
+/**
+ * テキストノード内の略称をリンクに変換する
  */
 const convertToLink = (node: Text, abbreviations: Abbreviation[]) => {
   const container = document.createElement("span");
-  let lastIndex = 0;
   const text = node.textContent || "";
+  let lastIndex = 0;
 
+  // 各略称ごとにマッチ箇所を検索（複数略称が同一ノード内にある場合にも対応）
+  // ※複数パターンが混在する場合、処理順序に注意が必要です
+  // ここでは全略称について、テキスト全体を走査する方法を採用
+  const matches: { index: number; term: string; length: number }[] = [];
   abbreviations.forEach((abbr) => {
     const pattern = new RegExp(abbr.term, "g");
-    let match: RegExpExecArray | null;
-
-    while ((match = pattern.exec(text)) !== null) {
-      // マッチ前のテキストを追加
-      container.appendChild(
-        document.createTextNode(text.slice(lastIndex, match.index))
-      );
-
-      // リンクを作成
-      const link = document.createElement("a");
-      link.href = `#${abbr.id}`;
-      link.textContent = abbr.term;
-      container.appendChild(link);
-
-      lastIndex = pattern.lastIndex;
+    let m: RegExpExecArray | null;
+    while ((m = pattern.exec(text)) !== null) {
+      matches.push({ index: m.index, term: abbr.term, length: m[0].length });
     }
+  });
+  // マッチ箇所でインデックス順にソート
+  matches.sort((a, b) => a.index - b.index);
+
+  matches.forEach((match) => {
+    if (match.index < lastIndex) {
+      return; // すでに置換済みの部分はスキップ
+    }
+    // マッチ前のテキストを追加
+    container.appendChild(
+      document.createTextNode(text.slice(lastIndex, match.index))
+    );
+    // 対応する略称のIDを取得
+    const abbr = abbreviations.find((a) => a.term === match.term);
+    const link = document.createElement("a");
+    link.href = abbr ? `#${abbr.id}` : "#";
+    link.textContent = match.term;
+    container.appendChild(link);
+    lastIndex = match.index + match.length;
   });
 
   // 残りのテキストを追加
   if (lastIndex < text.length) {
     container.appendChild(document.createTextNode(text.slice(lastIndex)));
   }
-
   node.parentNode?.replaceChild(container, node);
 };
 
@@ -65,40 +89,32 @@ const convertToLink = (node: Text, abbreviations: Abbreviation[]) => {
  */
 async function processAbbreviations() {
   try {
-    const elements = await querySelectorAllWithDelay("p.sentence");
+    // .article クラスを持つ要素全体を対象に（<div>、<article>の両方に対応）
+    const elements = await querySelectorAllWithDelay(".article");
     const abbreviations: Abbreviation[] = [];
 
-    // 略称を収集
+    // 各記事内のすべてのテキストノードから略称定義を収集
     elements.forEach((element) => {
-      const textNodes = Array.from(element.childNodes).filter(
-        (node) => node.nodeType === Node.TEXT_NODE
-      ) as Text[];
-
+      const textNodes = getTextNodes(element);
       textNodes.forEach((node) => {
         const text = node.textContent || "";
         const abbr = extractAbbreviation(text);
         if (abbr) {
-          console.log(`Found abbreviation: ${abbr}`); // 追加
+          console.log(`Found abbreviation: ${abbr}`);
           const id = findParentId(element);
           if (id) {
-            console.log(`Found ID: ${id}`); // 追加
+            console.log(`Found ID: ${id}`);
             abbreviations.push({ term: abbr, id });
           }
         }
       });
     });
 
-    // 略称が見つからなかったとき
-    if (abbreviations.length === 0) {
-      return;
-    }
+    if (abbreviations.length === 0) return;
 
-    // 略称をリンクに変換
+    // 収集した略称をすべての記事内のテキストノードに適用
     elements.forEach((element) => {
-      const textNodes = Array.from(element.childNodes).filter(
-        (node) => node.nodeType === Node.TEXT_NODE
-      ) as Text[];
-
+      const textNodes = getTextNodes(element);
       textNodes.forEach((node) => {
         convertToLink(node, abbreviations);
       });
@@ -112,7 +128,6 @@ const AbbreviationLinker: React.FC = () => {
   useEffect(() => {
     processAbbreviations();
   }, []);
-
   return null;
 };
 

--- a/src/content/HoverTooltip.tsx
+++ b/src/content/HoverTooltip.tsx
@@ -181,13 +181,14 @@ const HoverTooltip: React.FC = () => {
     };
 
     // .main-content 内の全リンクに対してイベントを設定する
-    const processMainContentLinks = (root: ParentNode = document) => {
-      const links: any =
-        root.querySelectorAll<HTMLAnchorElement>(".main-content a");
+    const processMainContentLinks = (root: ParentNode = document): void => {
+      const links = root.querySelectorAll<HTMLAnchorElement>(
+        "main.main-content a"
+      );
       links.forEach((link: HTMLAnchorElement) => {
         if (!link.dataset.hoverTooltipInitialized) {
           link.dataset.hoverTooltipInitialized = "true";
-          setupLinkEvents(link as HTMLAnchorElement);
+          setupLinkEvents(link);
         }
       });
     };

--- a/src/content/HoverTooltip.tsx
+++ b/src/content/HoverTooltip.tsx
@@ -1,4 +1,3 @@
-// src/content/HoverTooltip.tsx
 import React, { useEffect } from "react";
 
 const HoverTooltip: React.FC = () => {
@@ -21,20 +20,14 @@ const HoverTooltip: React.FC = () => {
           const tooltip = document.querySelector(
             `[data-tooltip-id="${tooltipId}"]`
           );
-          // ポップアップが存在しないか、ホバー中なら何もしない
           if (!tooltip || tooltip.matches(":hover")) return;
-
           tooltip.remove();
           const parentRect = tooltip.getBoundingClientRect();
           const childTooltips = document.querySelectorAll(".hover-tooltip");
-
           childTooltips.forEach((childTooltip) => {
             const childTooltipElement = childTooltip as HTMLElement;
-            // 自分自身なら無視
             if (childTooltipElement.dataset.tooltipId === tooltipId) return;
-
             const childRect = childTooltipElement.getBoundingClientRect();
-            // 親の右側にある要素のみ削除
             if (childRect.left > parentRect.left) {
               childTooltip.remove();
             }
@@ -121,9 +114,7 @@ const HoverTooltip: React.FC = () => {
       // ポップアップのホバーイベント
       tooltip.addEventListener("mouseenter", () => {
         clearHideTimeout(tooltipId);
-        if (parentTooltipId) {
-          clearHideTimeout(parentTooltipId);
-        }
+        if (parentTooltipId) clearHideTimeout(parentTooltipId);
       });
 
       tooltip.addEventListener("mouseleave", (e: MouseEvent) => {
@@ -143,9 +134,7 @@ const HoverTooltip: React.FC = () => {
 
         if (!isMovingToChild) {
           scheduleHideTooltip(tooltipId);
-          if (parentTooltipId) {
-            scheduleHideTooltip(parentTooltipId);
-          }
+          if (parentTooltipId) scheduleHideTooltip(parentTooltipId);
         }
       });
 
@@ -191,29 +180,26 @@ const HoverTooltip: React.FC = () => {
       });
     };
 
-    // 既存および追加された p.sentence 内のリンクへイベントをセットアップする関数
-    const processSentenceLinks = (root: ParentNode = document) => {
-      const sentences = root.querySelectorAll("p.sentence");
-      sentences.forEach((sentence) => {
-        const links = sentence.querySelectorAll("a");
-        links.forEach((link) => {
-          if (!link.dataset.hoverTooltipInitialized) {
-            link.dataset.hoverTooltipInitialized = "true";
-            setupLinkEvents(link as HTMLAnchorElement);
-          }
-        });
+    // .main-content 内の全リンクに対してイベントを設定する
+    const processMainContentLinks = (root: ParentNode = document) => {
+      const links: any =
+        root.querySelectorAll<HTMLAnchorElement>(".main-content a");
+      links.forEach((link: HTMLAnchorElement) => {
+        if (!link.dataset.hoverTooltipInitialized) {
+          link.dataset.hoverTooltipInitialized = "true";
+          setupLinkEvents(link as HTMLAnchorElement);
+        }
       });
     };
 
-    // 初回レンダリング時に既存リンクを処理
-    processSentenceLinks();
+    // 初回レンダリング時に .main-content 内のリンクを処理
+    processMainContentLinks();
 
-    // MutationObserver を利用して DOM 変更時に新たなリンクへイベントを設定
     const observer = new MutationObserver((mutationsList) => {
       mutationsList.forEach((mutation) => {
         mutation.addedNodes.forEach((node) => {
           if (node.nodeType === Node.ELEMENT_NODE) {
-            processSentenceLinks(node as Element);
+            processMainContentLinks(node as Element);
           }
         });
       });

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -17,8 +17,8 @@ function initialize() {
       <UnderlineBrackets />
       <AbbreviationLinker />
       <DecorateLawTitles />
-      <ExternalLinkPopover />
       <HoverTooltip />
+      <ExternalLinkPopover />
     </>
   );
 }

--- a/src/content/index.tsx
+++ b/src/content/index.tsx
@@ -17,8 +17,8 @@ function initialize() {
       <UnderlineBrackets />
       <AbbreviationLinker />
       <DecorateLawTitles />
-      <HoverTooltip />
       <ExternalLinkPopover />
+      <HoverTooltip />
     </>
   );
 }


### PR DESCRIPTION
以下〜「○○」という。
以下〜「○○」と総称する。

がリンク化されるように修正
以下のページで動いていることは確認してます

- 商法
https://laws.e-gov.go.jp/law/132AC0000000048#Mp-Pa_1-Ch_4-At_16

- 中小企業信用保険法
https://laws.e-gov.go.jp/law/325AC0000000264#Mp-At_5